### PR TITLE
[misc] Tighten commit-msg hook

### DIFF
--- a/git-hooks/commit-msg
+++ b/git-hooks/commit-msg
@@ -6,8 +6,9 @@
 #
 # client-side git-hook - checks commit message style
 
-head -n 1 "$1" | egrep -x '\[[^]]+\] [[:upper:]].*[^.]' > /dev/null
+pattern='\[(core|frontend|twitter|telegram|email|xmpp|mastodon|tests|doc|misc)\] [[:upper:]].*[^.]'
+head -n 1 "$1" | egrep -x "$pattern" > /dev/null
 if [ $? -ne 0 ]; then
-    echo "commit message doesn't match style" >&2
+    echo "commit message doesn't match \"$pattern\"" >&2
     exit 1
 fi


### PR DESCRIPTION
Make commit-msg hook tighter.
Reminder: Use this hook in your local git repo with `ln -s ../../git-hooks/commit-msg .git/hooks/commit-msg`.