### PR TITLE
[core] Add verbose flag to cli

### DIFF
--- a/kibicara/config.py
+++ b/kibicara/config.py
@@ -41,6 +41,9 @@ if argv[0].endswith('kibicara'):
         default='/etc/kibicara.conf',
         help='path to config file',
     )
+    parser.add_argument(
+        '-v', '--verbose', action="count", help="Raise verbosity level",
+    )
     args = parser.parse_args()
 
     try:

--- a/kibicara/kibicara.py
+++ b/kibicara/kibicara.py
@@ -10,11 +10,11 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from hypercorn.config import Config
 from hypercorn.asyncio import serve
-from kibicara.config import config
+from kibicara.config import args, config
 from kibicara.model import Mapping
 from kibicara.platformapi import Spawner
 from kibicara.webapi import router
-from logging import basicConfig, DEBUG, getLogger, WARNING
+from logging import basicConfig, DEBUG, getLogger, INFO, WARNING
 
 
 logger = getLogger(__name__)
@@ -31,7 +31,15 @@ class Main:
         asyncio_run(self.__run())
 
     async def __run(self):
-        basicConfig(level=DEBUG, format="%(asctime)s %(name)s %(message)s")
+        LOGLEVELS = {
+            None: WARNING,
+            1: INFO,
+            2: DEBUG,
+        }
+        basicConfig(
+            level=LOGLEVELS.get(args.verbose, DEBUG),
+            format="%(asctime)s %(name)s %(message)s",
+        )
         getLogger('aiosqlite').setLevel(WARNING)
         Mapping.create_all()
         await Spawner.init_all()


### PR DESCRIPTION
This adds a way to capture how verbose the logger should be, based on the amount of `v` flags you use (so `-v` vs `-vv`, for example).

To set the logging level, something like
```python
log = logging.getLogger(__name__) # ignore this if logger already exists
LOGLEVELS = {None: logging.WARNING,  # 0
             0: logging.WARNING,
             1: logging.INFO,
             2: logging.DEBUG,
             }
log.setLevel(LOGLEVELS.get(args.verbose, logging.DEBUG))
```
could be used