### PR TITLE
[frontend] Add button for hood page to dashboard

### DIFF
--- a/kibicara-frontend/src/app/dashboard/hoods/hoods.component.html
+++ b/kibicara-frontend/src/app/dashboard/hoods/hoods.component.html
@@ -18,6 +18,9 @@
             <mat-icon>settings</mat-icon>
             <div class="list-entry">
               Your Hood - <strong>{{ hood.name }}</strong>
+	      <a [routerLink]="['/hoods', hood.id]">
+  	        <mat-icon class="list-entry-page">open_in_browser</mat-icon>
+	      </a>
             </div>
           </div>
           <mat-divider></mat-divider>

--- a/kibicara-frontend/src/app/dashboard/hoods/hoods.component.html
+++ b/kibicara-frontend/src/app/dashboard/hoods/hoods.component.html
@@ -6,27 +6,40 @@
       supports each other. Kibicara hoods will support you by providing the
       technology for your community to florish!
     </p>
-    <mat-selection-list [multiple]="false">
-      <div mat-subheader>Configure your hoods</div>
-      <mat-divider></mat-divider>
-      <a
-        *ngFor="let hood of hoods$ | async"
-        [routerLink]="['/dashboard/hoods', hood.id]"
-      >
-        <mat-list-option>
-          <div class="list-entry-container">
-            <mat-icon>settings</mat-icon>
-            <div class="list-entry">
-              Your Hood - <strong>{{ hood.name }}</strong>
-	      <a [routerLink]="['/hoods', hood.id]">
-  	        <mat-icon class="list-entry-page">open_in_browser</mat-icon>
-	      </a>
+    <div class="hoods-container">
+      <mat-selection-list [multiple]="false">
+        <div mat-subheader>Configure your hoods</div>
+        <mat-divider></mat-divider>
+        <a
+          *ngFor="let hood of hoods$ | async"
+          [routerLink]="['/dashboard/hoods', hood.id]"
+          target="_blank"
+          matTooltip="Edit settings of {{ hood.name }}"
+        >
+          <mat-list-option>
+            <div class="list-entry-container">
+              <mat-icon>settings</mat-icon>
+              <div class="list-entry">
+                Your Hood - <strong>{{ hood.name }}</strong>
+              </div>
             </div>
-          </div>
-          <mat-divider></mat-divider>
-        </mat-list-option>
-      </a>
-    </mat-selection-list>
+            <mat-divider></mat-divider>
+          </mat-list-option>
+        </a>
+      </mat-selection-list>
+      <mat-list>
+        <div mat-subheader></div>
+        <mat-list-item *ngFor="let hood of hoods$ | async">
+          <a
+            [routerLink]="['/hoods', hood.id]"
+            matTooltip="View public page of hood {{ hood.name }}"
+          >
+            <mat-icon class="open-icon">open_in_new</mat-icon>
+          </a>
+        </mat-list-item>
+      </mat-list>
+    </div>
+
     <button
       mat-raised-button
       color="primary"

--- a/kibicara-frontend/src/app/dashboard/hoods/hoods.component.scss
+++ b/kibicara-frontend/src/app/dashboard/hoods/hoods.component.scss
@@ -63,7 +63,14 @@ p {
   grid-template-columns: 30px 1fr;
 }
 
-.list-entry-page {
-  float: right;
+.hoods-container {
+  display: grid;
+  grid-template-columns: 1fr 65px;
+  gap: 10px;
+  justify-items: stretch;
+  align-items: stretch;
+}
+
+.open-icon {
   color: black;
 }

--- a/kibicara-frontend/src/app/dashboard/hoods/hoods.component.scss
+++ b/kibicara-frontend/src/app/dashboard/hoods/hoods.component.scss
@@ -62,3 +62,8 @@ p {
   display: grid;
   grid-template-columns: 30px 1fr;
 }
+
+.list-entry-page {
+  float: right;
+  color: black;
+}


### PR DESCRIPTION
As discussed:

![Screenshot_2020-09-06_13-02-43](https://user-images.githubusercontent.com/67834589/92324367-56eaf280-f041-11ea-871f-db013e48d1d5.png)

The button on the right opens the hood page in the same tab. I quickly glanced over the material icons, that one looked good enough. We could also open it in a new tab I guess... I have no preference for that^^